### PR TITLE
tune: lower proportional_acc_max to fix lateral strafe drift

### DIFF
--- a/lekiwi_control/config/base_controllers.yaml
+++ b/lekiwi_control/config/base_controllers.yaml
@@ -68,8 +68,8 @@ base_controller:
     # max_acceleration: SOFTWARE ramp limit applied by OmniWheelDriveController to incoming cmd_vel.
     #   The sts_hardware_interface uses proportional per-wheel ACC so all wheels finish ramping in equal time.
     #   This requires the per-cycle velocity step to be large enough that the hardware ramp spans at least one
-    #   control cycle (20ms at 50Hz). Values below ~2 m/s² make per-cycle steps so small (~0.39 rad/s back wheel)
-    #   that hardware finishes in <5ms regardless of ACC, negating the proportional ACC effect. 
+    #   control cycle (20ms at 50Hz). Values below ~2 m/s² make per-cycle steps so small (~0.78 rad/s back wheel,
+    #   ~0.39 rad/s front wheels) that hardware finishes in <5ms regardless of ACC, negating the proportional ACC effect. 
     #   Use physics-derived values (~100ms to full speed).
     linear:
       x:

--- a/lekiwi_control/config/base_controllers.yaml
+++ b/lekiwi_control/config/base_controllers.yaml
@@ -66,17 +66,19 @@ base_controller:
     # Derived from max_velocity_steps=2890: wheel_omega=4.43 rad/s, wheel_radius=0.051m, robot_radius=0.132239m
     #
     # max_acceleration: SOFTWARE ramp limit applied by OmniWheelDriveController to incoming cmd_vel.
-    #   The hardware (STS3215) acceleration register receives 0 (= maximum hardware slew rate, no ramp limiting),
-    #   because OmniWheelDriveController does not write the acceleration command interface.
-    #   These values therefore fully control how quickly the robot responds to velocity commands.
+    #   The hardware (sts_hardware_interface) uses proportional per-wheel ACC so all wheels finish
+    #   ramping in equal time. This requires the per-cycle velocity step to be large enough that the
+    #   hardware ramp spans at least one control cycle (20ms at 50Hz). Values below ~2 m/s² make
+    #   per-cycle steps so small (~0.39 rad/s back wheel) that hardware finishes in <5ms regardless
+    #   of ACC, negating the proportional ACC effect. Use physics-derived values (~100ms to full speed).
     linear:
       x:
         max_velocity: 0.261  # m/s  (0.051 * 4.43 / sin(60°))
-        max_acceleration: 1.0 # 2.61 m/s^2  (~100ms ramp to full speed)
+        max_acceleration: 2.61  # m/s^2  (~100ms ramp to full speed)
       y:
         max_velocity: 0.226  # m/s  (0.051 * 4.43)
-        max_acceleration: 1.0 # 2.26 m/s^2  (~100ms ramp to full speed)
+        max_acceleration: 2.26  # m/s^2  (~100ms ramp to full speed)
     angular:
       z:
         max_velocity: 1.71  # rad/s  (0.051 * 4.43 / 0.132239)
-        max_acceleration: 10.0 # 17.1 rad/s^2  (~100ms ramp to full speed)
+        max_acceleration: 17.1  # rad/s^2  (~100ms ramp to full speed)

--- a/lekiwi_control/config/base_controllers.yaml
+++ b/lekiwi_control/config/base_controllers.yaml
@@ -72,11 +72,11 @@ base_controller:
     linear:
       x:
         max_velocity: 0.261  # m/s  (0.051 * 4.43 / sin(60°))
-        max_acceleration: 2.61  # m/s^2  (~100ms ramp to full speed)
+        max_acceleration: 1.0 # 2.61 m/s^2  (~100ms ramp to full speed)
       y:
         max_velocity: 0.226  # m/s  (0.051 * 4.43)
-        max_acceleration: 2.26  # m/s^2  (~100ms ramp to full speed)
+        max_acceleration: 1.0 # 2.26 m/s^2  (~100ms ramp to full speed)
     angular:
       z:
         max_velocity: 1.71  # rad/s  (0.051 * 4.43 / 0.132239)
-        max_acceleration: 17.1  # rad/s^2  (~100ms ramp to full speed)
+        max_acceleration: 10.0 # 17.1 rad/s^2  (~100ms ramp to full speed)

--- a/lekiwi_description/urdf/base.control.xacro
+++ b/lekiwi_description/urdf/base.control.xacro
@@ -15,7 +15,7 @@
   <!-- ACC given to the wheel with the largest |target - current| velocity delta. -->
   <!-- All others scaled proportionally so every wheel finishes ramping in equal time. -->
   <!-- Set proportional_acc_max to 0 to disable (ACC=0 for all wheels). -->
-  <xacro:property name="proportional_acc_max" value="100"/>       <!-- [0-254] -->
+  <xacro:property name="proportional_acc_max" value="25"/>        <!-- [0-254] -->
   <xacro:property name="proportional_acc_deadband" value="0.05"/> <!-- rad/s, below this max-delta ACC=0 (steady-state cruise) -->
 
   <!-- Motor IDs and mode -->

--- a/lekiwi_description/urdf/base.control.xacro
+++ b/lekiwi_description/urdf/base.control.xacro
@@ -11,6 +11,13 @@
   <!-- Adjust for other motor models: STS3032 max=2900, STS3235 max=3400 -->
   <xacro:property name="sts_max_velocity_steps" value="3400"/>  <!-- Max hardware velocity in steps/s (absolute motor limit, do not exceed) -->
 
+  <!-- Proportional ACC parameters (SyncWriteSpe velocity path only) -->
+  <!-- ACC given to the wheel with the largest |target - current| velocity delta. -->
+  <!-- All others scaled proportionally so every wheel finishes ramping in equal time. -->
+  <!-- Set proportional_acc_max to 0 to disable (ACC=0 for all wheels). -->
+  <xacro:property name="proportional_acc_max" value="100"/>       <!-- [0-254] -->
+  <xacro:property name="proportional_acc_deadband" value="0.05"/> <!-- rad/s, below this max-delta ACC=0 (steady-state cruise) -->
+
   <!-- Motor IDs and mode -->
   <xacro:property name="left_motor_id" value="7"/>
   <xacro:property name="back_motor_id" value="8"/>

--- a/lekiwi_description/urdf/base.urdf.xacro
+++ b/lekiwi_description/urdf/base.urdf.xacro
@@ -230,6 +230,9 @@
       <param name="enable_mock_mode">$(arg use_mock)</param>
       <!-- Motor-specific parameter (adjust for different STS motor models) -->
       <param name="max_velocity_steps">${sts_max_velocity_steps}</param>
+      <!-- Proportional ACC: scale per-wheel acceleration so all wheels finish ramping in equal time -->
+      <param name="proportional_acc_max">${proportional_acc_max}</param>
+      <param name="proportional_acc_deadband">${proportional_acc_deadband}</param>
     </hardware>
     <!-- Left wheel joint (Motor ID 7) -->
     <joint name="left_wheel_joint">


### PR DESCRIPTION
## Summary

- Reduces `proportional_acc_max` from 100 → 25 in `base.control.xacro`
- Restores software acceleration limits to physics-derived values (2.61 / 2.26 / 17.1 m/s²) in `base_controllers.yaml`
- Updates comment to document the >2 m/s² per-cycle-step requirement

## Problem

During pure lateral (Y) strafe, the back wheel is commanded at 2× the speed of the front wheels. With `proportional_acc_max = 100`, the scaled ACC values (e.g. 50 for front wheels) still ramp to target in <5ms — faster than one 20ms control cycle — making proportional synchronisation irrelevant. The result: front wheels lag or stop before the back wheel, causing chassis rotation and a twitch on stick release.

Reducing software acceleration limits to 1.0 m/s² made it worse: per-cycle steps become so small that hardware completes them instantaneously regardless of ACC, further negating synchronisation.

## Fix

`proportional_acc_max = 25` makes the slowest ramp span ~100ms (5 control cycles). Proportional scaling now has time to actually synchronise wheel arrival, so all three wheels reach their targets simultaneously during acceleration and deceleration.

## Test plan

- [ ] Drive robot forward/backward — confirm no regression
- [ ] Strafe left/right — confirm no chassis rotation during move
- [ ] Release stick mid-strafe — confirm no twitch
- [ ] Rotate — confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified proportional per-wheel acceleration behavior, noting ramps finish in equal time, the minimum step must span one control cycle (e.g., 20ms at 50Hz), tiny per-cycle steps can finish <5ms, and recommending physics-based ramps (~100ms to full speed).

* **New Features**
  * Added configurable proportional acceleration (default 25) and a small-speed deadband (default 0.05 rad/s) for finer per-wheel tuning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->